### PR TITLE
Allow No Name 

### DIFF
--- a/hello_app/templates/hello_there.html
+++ b/hello_app/templates/hello_there.html
@@ -9,7 +9,7 @@
         {%if name %}
             <span class="message">Hello there, {{ name }}!</span> It's {{ date.strftime("%A, %d %B, %Y at %X") }}.
         {% else %}
-            <span class="message">You must provide a name.</span>
+            <span class="message">What's your name? Provide it after /hello/ in the URL.</span>
         {% endif %}
     </body>
 </html>

--- a/hello_app/templates/hello_there.html
+++ b/hello_app/templates/hello_there.html
@@ -6,7 +6,11 @@
         <title>Hello, Flask</title>
     </head>
     <body>
-        <span class="message">Hello there, {{ name }}!</span> It's {{ date.strftime("%A, %d %B, %Y at %X") }}.
+        {%if name %}
+            <span class="message">Hello there, {{ name }}!</span> It's {{ date.strftime("%A, %d %B, %Y at %X") }}.
+        {% else %}
+            <span class="message">You must provide a name.</span>
+        {% endif %}
     </body>
 </html>
 <!-- The above syntax makes use of jinja and it's documentation can be found over here http://jinja.pocoo.org/docs/2.10/templates/ -->

--- a/hello_app/views.py
+++ b/hello_app/views.py
@@ -14,8 +14,9 @@ def about():
 def contact():
     return render_template("contact.html")
 
+@app.route("/hello")
 @app.route("/hello/<name>")
-def hello_there(name):
+def hello_there(name = None):
     return render_template(
         "hello_there.html",
         name=name,


### PR DESCRIPTION
On the route hello, a little bit of code was added to make the page not require a value for "Name" to be provided.  Original functionally is not changed, however if name is not provided then a message on the screen says "You must provide a name" instead of getting the error "Not Found
The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again."