### PR TITLE
Update markupsafe newest version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,36 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+pool:
+  vmImage: 'ubuntu-latest'
+strategy:
+  matrix:
+    Python27:
+      python.version: '2.7'
+    Python35:
+      python.version: '3.5'
+    Python36:
+      python.version: '3.6'
+    Python37:
+      python.version: '3.7'
+
+steps:
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '$(python.version)'
+  displayName: 'Use Python $(python.version)'
+
+- script: |
+    python -m pip install --upgrade pip
+    pip install -r requirements.txt
+  displayName: 'Install dependencies'
+
+- script: |
+    pip install pytest pytest-azurepipelines
+    pytest
+  displayName: 'pytest'

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ click==6.7
 Flask==1.0.2
 itsdangerous==0.24
 Jinja2>=2.10.1
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 Werkzeug==0.15.5


### PR DESCRIPTION
according to: https://github.com/pallets/markupsafe/issues/57 
updating markupsafe to 1.1.1 should resolve the issue with 

Collecting MarkupSafe==1.0
  Downloading MarkupSafe-1.0.tar.gz (14 kB)
    ERROR: Command errored out with exit status 1: